### PR TITLE
Basic implementation of coordinators

### DIFF
--- a/Coordinators.xcodeproj/project.pbxproj
+++ b/Coordinators.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E344C2B2226D19C200705B0F /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E344C2B1226D19C200705B0F /* Coordinator.swift */; };
+		E344C2B4226D1BF100705B0F /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E344C2B3226D1BF100705B0F /* AppCoordinator.swift */; };
+		E344C2B7226D1CA100705B0F /* Storyboarded.swift in Sources */ = {isa = PBXBuildFile; fileRef = E344C2B6226D1CA100705B0F /* Storyboarded.swift */; };
 		E3D76002226CF09800C077BC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3D76001226CF09800C077BC /* AppDelegate.swift */; };
 		E3D76007226CF09800C077BC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E3D76005226CF09800C077BC /* Main.storyboard */; };
 		E3D76009226CF09A00C077BC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E3D76008226CF09A00C077BC /* Assets.xcassets */; };
@@ -28,6 +31,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		E344C2B1226D19C200705B0F /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
+		E344C2B3226D1BF100705B0F /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		E344C2B6226D1CA100705B0F /* Storyboarded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storyboarded.swift; sourceTree = "<group>"; };
 		E3D75FFE226CF09800C077BC /* Coordinators.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Coordinators.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3D76001226CF09800C077BC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E3D76006226CF09800C077BC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -60,6 +66,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		E344C2B5226D1C9800705B0F /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				E344C2B1226D19C200705B0F /* Coordinator.swift */,
+				E344C2B6226D1CA100705B0F /* Storyboarded.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
 		E3D75FF5226CF09800C077BC = {
 			isa = PBXGroup;
 			children = (
@@ -81,13 +96,15 @@
 		E3D76000226CF09800C077BC /* Coordinators */ = {
 			isa = PBXGroup;
 			children = (
-				E3D76026226CF53300C077BC /* User */,
-				E3D76021226CF3B200C077BC /* Products */,
+				E344C2B3226D1BF100705B0F /* AppCoordinator.swift */,
 				E3D76001226CF09800C077BC /* AppDelegate.swift */,
-				E3D76005226CF09800C077BC /* Main.storyboard */,
 				E3D76008226CF09A00C077BC /* Assets.xcassets */,
-				E3D7600A226CF09A00C077BC /* LaunchScreen.storyboard */,
 				E3D7600D226CF09A00C077BC /* Info.plist */,
+				E3D7600A226CF09A00C077BC /* LaunchScreen.storyboard */,
+				E3D76005226CF09800C077BC /* Main.storyboard */,
+				E3D76021226CF3B200C077BC /* Products */,
+				E344C2B5226D1C9800705B0F /* Protocols */,
+				E3D76026226CF53300C077BC /* User */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -219,10 +236,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E344C2B4226D1BF100705B0F /* AppCoordinator.swift in Sources */,
 				E3D76028226CF56500C077BC /* LoginViewController.swift in Sources */,
 				E3D76025226CF3FE00C077BC /* ThankYouViewController.swift in Sources */,
+				E344C2B2226D19C200705B0F /* Coordinator.swift in Sources */,
 				E3D76023226CF3DD00C077BC /* ProductListViewController.swift in Sources */,
 				E3D76002226CF09800C077BC /* AppDelegate.swift in Sources */,
+				E344C2B7226D1CA100705B0F /* Storyboarded.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Coordinators/AppCoordinator.swift
+++ b/Coordinators/AppCoordinator.swift
@@ -1,0 +1,41 @@
+//
+//  AppCoordinator.swift
+//  Coordinators
+//
+//  Created by Miguel Herrero on 21/04/2019.
+//  Copyright © 2019 Miguel Herrero. All rights reserved.
+//
+
+import UIKit
+
+class AppCoordinator: Coordinator {
+    var childCoordinators: [Coordinator] = [Coordinator]()
+    var navigationController: UINavigationController
+
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+
+    func start() {
+        let vc = ProductListViewController.instantiate()
+        vc.coordinator = self
+        navigationController.pushViewController(vc, animated: false)
+    }
+
+    func buyProduct(id: String) {
+        let vc = ThankYouViewController.instantiate()
+        vc.coordinator = self
+        vc.productId = id
+        navigationController.pushViewController(vc, animated: true)
+    }
+
+    func routeToProductList() {
+        navigationController.popToRootViewController(animated: true)
+    }
+
+    func login() {
+        let vc = LoginViewController.instantiate()
+        vc.coordinator = self
+        navigationController.pushViewController(vc, animated: true)
+    }
+}

--- a/Coordinators/AppDelegate.swift
+++ b/Coordinators/AppDelegate.swift
@@ -12,10 +12,23 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-
+    private var coordinator : AppCoordinator!
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        // create the main navigation controller to be used for our app
+        let navigationController = UINavigationController()
+
+        // send that into our coordinator so that it can display view controllers
+        coordinator = AppCoordinator(navigationController: navigationController)
+
+        // tell the coordinator to take over control
+        coordinator?.start()
+
+        // create a basic UIWindow and activate it
+        window = UIWindow(frame: UIScreen.main.bounds)
+        window?.rootViewController = navigationController
+        window?.makeKeyAndVisible()
+
         return true
     }
 

--- a/Coordinators/Base.lproj/Main.storyboard
+++ b/Coordinators/Base.lproj/Main.storyboard
@@ -109,7 +109,6 @@
                                 <state key="normal" title="Cancel"/>
                                 <connections>
                                     <action selector="cancelLoginTapped:" destination="8AQ-UZ-Uyy" eventType="touchUpInside" id="uWH-ep-tEQ"/>
-                                    <segue destination="oLG-qZ-LVe" kind="unwind" identifier="unwindSegueToProductList" unwindAction="unwindToProductListWithSegue:" id="VCL-PM-DS4"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -132,7 +131,6 @@
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eXw-mo-dwL" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <exit id="oLG-qZ-LVe" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="1096" y="835"/>
         </scene>
@@ -161,7 +159,6 @@
                                 <state key="normal" title="Go to product list"/>
                                 <connections>
                                     <action selector="goToProductListTapped:" destination="IfP-pk-sJ5" eventType="touchUpInside" id="Stm-oA-39f"/>
-                                    <segue destination="r0X-2w-Xes" kind="unwind" identifier="unwindSegueToProductList" unwindAction="unwindToProductListWithSegue:" id="YXB-g2-2cH"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -181,7 +178,6 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="sUf-Oi-Scx" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <exit id="r0X-2w-Xes" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="1854" y="112"/>
         </scene>

--- a/Coordinators/Base.lproj/Main.storyboard
+++ b/Coordinators/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="KfO-2k-95N">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -19,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="List of Products" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vdb-Kf-HyC">
-                                <rect key="frame" x="119.5" y="64" width="175" height="32"/>
+                                <rect key="frame" x="120" y="64" width="174.5" height="32"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -28,28 +28,28 @@
                                 <rect key="frame" x="158" y="206" width="98" height="30"/>
                                 <state key="normal" title="Buy Product 2"/>
                                 <connections>
-                                    <segue destination="IfP-pk-sJ5" kind="show" identifier="BuyProduct2" id="GjX-Tb-IoY"/>
+                                    <action selector="buyProductTwoTapped:" destination="KfO-2k-95N" eventType="touchUpInside" id="GX8-0D-byr"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WL5-At-iX6">
                                 <rect key="frame" x="158" y="256" width="98" height="30"/>
                                 <state key="normal" title="Buy Product 3"/>
                                 <connections>
-                                    <segue destination="IfP-pk-sJ5" kind="show" identifier="BuyProduct3" id="Fcy-TM-5TG"/>
+                                    <action selector="buyProductThreeTapped:" destination="KfO-2k-95N" eventType="touchUpInside" id="jjz-ku-9ws"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QYc-qU-3iy">
                                 <rect key="frame" x="356" y="64" width="38" height="30"/>
                                 <state key="normal" title="Login"/>
                                 <connections>
-                                    <segue destination="8AQ-UZ-Uyy" kind="show" identifier="Login" id="air-g8-fhZ"/>
+                                    <action selector="loginTapped:" destination="KfO-2k-95N" eventType="touchUpInside" id="hSe-fJ-BiU"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="re4-Ip-26x">
                                 <rect key="frame" x="159" y="156" width="96" height="30"/>
                                 <state key="normal" title="Buy Product 1"/>
                                 <connections>
-                                    <segue destination="IfP-pk-sJ5" kind="show" identifier="BuyProduct1" id="FLx-6w-3cs"/>
+                                    <action selector="buyProductOneTapped:" destination="KfO-2k-95N" eventType="touchUpInside" id="Knb-ip-cxX"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -57,6 +57,7 @@
                         <constraints>
                             <constraint firstItem="WL5-At-iX6" firstAttribute="top" secondItem="eRT-08-rpL" secondAttribute="bottom" constant="20" id="3a4-O4-Sx4"/>
                             <constraint firstItem="eRT-08-rpL" firstAttribute="centerX" secondItem="hag-SK-6XC" secondAttribute="centerX" id="4mu-7e-BBJ"/>
+                            <constraint firstItem="QYc-qU-3iy" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Vdb-Kf-HyC" secondAttribute="trailing" constant="1" id="90P-dL-bNE"/>
                             <constraint firstItem="Xc5-wX-dIk" firstAttribute="trailing" secondItem="QYc-qU-3iy" secondAttribute="trailing" constant="20" id="TH8-ls-qR0"/>
                             <constraint firstItem="QYc-qU-3iy" firstAttribute="top" secondItem="Xc5-wX-dIk" secondAttribute="top" constant="20" id="cBd-3W-37n"/>
                             <constraint firstItem="Vdb-Kf-HyC" firstAttribute="centerX" secondItem="hag-SK-6XC" secondAttribute="centerX" id="dyD-9S-oEc"/>
@@ -103,9 +104,8 @@
                                 <rect key="frame" x="188" y="256" width="38" height="30"/>
                                 <state key="normal" title="Login"/>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sun-Sk-mlz">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sun-Sk-mlz">
                                 <rect key="frame" x="183" y="306" width="48" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Cancel"/>
                                 <connections>
                                     <action selector="cancelLoginTapped:" destination="8AQ-UZ-Uyy" eventType="touchUpInside" id="uWH-ep-tEQ"/>
@@ -119,8 +119,10 @@
                             <constraint firstItem="kHT-Yx-MPi" firstAttribute="top" secondItem="sI5-uP-u7g" secondAttribute="bottom" constant="60" id="CpE-Oe-c9r"/>
                             <constraint firstItem="sI5-uP-u7g" firstAttribute="centerX" secondItem="5oe-Ei-U4i" secondAttribute="centerX" id="DYo-Q2-JFq"/>
                             <constraint firstItem="8QF-2e-cCZ" firstAttribute="leading" secondItem="4te-4q-LsF" secondAttribute="leading" constant="20" id="Q7v-uQ-9qF"/>
+                            <constraint firstItem="Sun-Sk-mlz" firstAttribute="centerX" secondItem="5oe-Ei-U4i" secondAttribute="centerX" id="VD6-ma-pIM"/>
                             <constraint firstItem="gkF-P3-UU8" firstAttribute="top" secondItem="8QF-2e-cCZ" secondAttribute="bottom" constant="20" id="WNd-R6-G4E"/>
                             <constraint firstItem="8QF-2e-cCZ" firstAttribute="top" secondItem="kHT-Yx-MPi" secondAttribute="bottom" constant="20" id="gD5-Ff-l5q"/>
+                            <constraint firstItem="Sun-Sk-mlz" firstAttribute="top" secondItem="gkF-P3-UU8" secondAttribute="bottom" constant="20" id="kg0-x6-Gdx"/>
                             <constraint firstItem="kHT-Yx-MPi" firstAttribute="leading" secondItem="4te-4q-LsF" secondAttribute="leading" constant="20" id="pOk-HO-Fsk"/>
                             <constraint firstItem="4te-4q-LsF" firstAttribute="trailing" secondItem="8QF-2e-cCZ" secondAttribute="trailing" constant="20" id="qAy-zk-Zky"/>
                             <constraint firstItem="gkF-P3-UU8" firstAttribute="centerX" secondItem="5oe-Ei-U4i" secondAttribute="centerX" id="wyk-Ie-l9g"/>
@@ -184,7 +186,4 @@
             <point key="canvasLocation" x="1854" y="112"/>
         </scene>
     </scenes>
-    <inferredMetricsTieBreakers>
-        <segue reference="GjX-Tb-IoY"/>
-    </inferredMetricsTieBreakers>
 </document>

--- a/Coordinators/Info.plist
+++ b/Coordinators/Info.plist
@@ -22,8 +22,6 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/Coordinators/Products/ProductListViewController.swift
+++ b/Coordinators/Products/ProductListViewController.swift
@@ -22,8 +22,6 @@ class ProductListViewController: UIViewController, Storyboarded {
 
     // MARK: - Actions
 
-    @IBAction func unwindToProductList(segue: UIStoryboardSegue) { }
-
     @IBAction func loginTapped(_ sender: Any) { coordinator?.login() }
     @IBAction func buyProductOneTapped(_ sender: Any) { coordinator?.buyProduct(id: "One") }
     @IBAction func buyProductTwoTapped(_ sender: Any) { coordinator?.buyProduct(id: "Two") }

--- a/Coordinators/Products/ProductListViewController.swift
+++ b/Coordinators/Products/ProductListViewController.swift
@@ -8,33 +8,24 @@
 
 import UIKit
 
-class ProductListViewController: UIViewController {
+class ProductListViewController: UIViewController, Storyboarded {
+
+    // MARK: - Variables
+
+    weak var coordinator: AppCoordinator?
+
+    // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
     }
+
+    // MARK: - Actions
 
     @IBAction func unwindToProductList(segue: UIStoryboardSegue) { }
 
-
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-        if segue.identifier == "BuyProduct1" {
-            let vc = segue.destination as! ThankYouViewController
-            vc.productId = "One"
-        } else if segue.identifier == "BuyProduct2" {
-            let vc = segue.destination as! ThankYouViewController
-            vc.productId = "Two"
-        } else if segue.identifier == "BuyProduct3" {
-            let vc = segue.destination as! ThankYouViewController
-            vc.productId = "Three"
-        }
-    }
-
+    @IBAction func loginTapped(_ sender: Any) { coordinator?.login() }
+    @IBAction func buyProductOneTapped(_ sender: Any) { coordinator?.buyProduct(id: "One") }
+    @IBAction func buyProductTwoTapped(_ sender: Any) { coordinator?.buyProduct(id: "Two") }
+    @IBAction func buyProductThreeTapped(_ sender: Any) { coordinator?.buyProduct(id: "Three") }
 }

--- a/Coordinators/Products/ThankYouViewController.swift
+++ b/Coordinators/Products/ThankYouViewController.swift
@@ -24,7 +24,6 @@ class ThankYouViewController: UIViewController, Storyboarded {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
         if let productId = productId {
             thankYouMessage.text = "You just bought product \(productId)"
         }

--- a/Coordinators/Products/ThankYouViewController.swift
+++ b/Coordinators/Products/ThankYouViewController.swift
@@ -8,10 +8,18 @@
 
 import UIKit
 
-class ThankYouViewController: UIViewController {
+class ThankYouViewController: UIViewController, Storyboarded {
 
+    // MARK: - Variables
+
+    weak var coordinator: AppCoordinator?
     var productId: String?
+
+    // MARK: - Outlets
+
     @IBOutlet weak var thankYouMessage: UILabel!
+
+    // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,19 +29,8 @@ class ThankYouViewController: UIViewController {
             thankYouMessage.text = "You just bought product \(productId)"
         }
     }
+
+    // MARK: - Actions
     
-    @IBAction func goToProductListTapped(_ sender: Any) {
-        performSegue(withIdentifier: "unwindSegueToProductList", sender: self)
-    }
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
+    @IBAction func goToProductListTapped(_ sender: Any) { coordinator?.routeToProductList() }
 }

--- a/Coordinators/Protocols/Coordinator.swift
+++ b/Coordinators/Protocols/Coordinator.swift
@@ -1,0 +1,16 @@
+//
+//  Coordinator.swift
+//  Coordinators
+//
+//  Created by Miguel Herrero on 21/04/2019.
+//  Copyright © 2019 Miguel Herrero. All rights reserved.
+//
+
+import UIKit
+
+protocol Coordinator: AnyObject {
+    var childCoordinators: [Coordinator] { get set }
+    var navigationController: UINavigationController { get set }
+
+    func start()
+}

--- a/Coordinators/Protocols/Storyboarded.swift
+++ b/Coordinators/Protocols/Storyboarded.swift
@@ -5,6 +5,8 @@
 //  Created by Miguel Herrero on 21/04/2019.
 //  Copyright © 2019 Miguel Herrero. All rights reserved.
 //
+//  SeeAlso: https://www.hackingwithswift.com/articles/71/how-to-use-the-coordinator-pattern-in-ios-apps
+//
 
 import UIKit
 
@@ -14,8 +16,13 @@ protocol Storyboarded {
 
 extension Storyboarded where Self: UIViewController {
     static func instantiate() -> Self {
+        // find the class name of requested view controller
         let id = String(describing: self)
+
+        // load our storyboard
         let storyboard = UIStoryboard(name: "Main", bundle: Bundle.main)
+
+        // instantiate a view controller with that identifier, and force cast as the type that was requested
         return storyboard.instantiateViewController(withIdentifier: id) as! Self
     }
 }

--- a/Coordinators/Protocols/Storyboarded.swift
+++ b/Coordinators/Protocols/Storyboarded.swift
@@ -1,0 +1,21 @@
+//
+//  Storyboarded.swift
+//  Coordinators
+//
+//  Created by Miguel Herrero on 21/04/2019.
+//  Copyright © 2019 Miguel Herrero. All rights reserved.
+//
+
+import UIKit
+
+protocol Storyboarded {
+    static func instantiate() -> Self
+}
+
+extension Storyboarded where Self: UIViewController {
+    static func instantiate() -> Self {
+        let id = String(describing: self)
+        let storyboard = UIStoryboard(name: "Main", bundle: Bundle.main)
+        return storyboard.instantiateViewController(withIdentifier: id) as! Self
+    }
+}

--- a/Coordinators/User/LoginViewController.swift
+++ b/Coordinators/User/LoginViewController.swift
@@ -8,7 +8,9 @@
 
 import UIKit
 
-class LoginViewController: UIViewController {
+class LoginViewController: UIViewController, Storyboarded {
+
+    weak var coordinator: AppCoordinator?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -16,18 +18,5 @@ class LoginViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
     
-    @IBAction func cancelLoginTapped(_ sender: Any) {
-        performSegue(withIdentifier: "unwindSegueToProductList", sender: self)
-    }
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
+    @IBAction func cancelLoginTapped(_ sender: Any) { coordinator?.routeToProductList() }
 }

--- a/Coordinators/User/LoginViewController.swift
+++ b/Coordinators/User/LoginViewController.swift
@@ -14,8 +14,6 @@ class LoginViewController: UIViewController, Storyboarded {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
     }
     
     @IBAction func cancelLoginTapped(_ sender: Any) { coordinator?.routeToProductList() }


### PR DESCRIPTION
In this PR we start implementing Coordinator pattern. Storyboard segues are substituted with calls to the AppCoordinator (father of each ViewController in this case) that handles where to go to (and pass data)



Result:
- Two procotols:
    - `Coordinator`, which has the “standard” variables and method.
    - `Storyboarded`, taken from Hacking with Swift, that helps to instantiate ViewControllers easily from Main.storyboard.
- `AppDelegate` instantiates the first coordinator (`AppCoordinator`) and tells the coordinator to take over control.
- ViewControllers have the coordinator assigned and execute one of its actions when required, abstracting from any segue or ViewController.
- The coordinator instantiates and navigates to the other ViewControllers.

To improve:
- Still ViewControllers know that “dismiss/cancel” action should route to some point. They should not. Maybe implement a `didFinish` method, and take control on where to go to (not necessarily `rootViewController`, like now).
- Investigate the use of `childCoordinators` to know how to navigate to some other place and pop ViewControllers appropriately.

Maybe continuing with [Advanced coordinators in iOS - Hacking with Swift](https://www.hackingwithswift.com/articles/175/advanced-coordinator-pattern-tutorial-ios)

![basic-coordinator](https://user-images.githubusercontent.com/465723/56476294-e9631400-6495-11e9-9dc0-2f120c8f9abe.gif)